### PR TITLE
Fix expertise text color

### DIFF
--- a/services.html
+++ b/services.html
@@ -169,7 +169,7 @@
       </div>
       </div>
 
-      <div class="mt-8 text-center text-lg">
+      <div class="mt-8 text-center text-lg text-white">
         <strong>Our Expertise Includes:</strong><br />
         ISO 9001:2015 • BRCGS Agents & Brokers • HACCP • other industry standards
       </div>


### PR DESCRIPTION
## Summary
- ensure bottom expertise text is visible on the Quality page

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856f348cafc832f99fa559a401c2f83