### PR TITLE
Fix footer positioning on data and chatbot pages

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -19,6 +19,10 @@
       font-weight: 400;
       font-size: 16px;
       line-height: 1.5;
+      margin: 0;
+      display: flex;
+      min-height: 100vh;
+      flex-direction: column;
     }
     :root {
       --primary: #1B1F3B;
@@ -178,7 +182,7 @@
   </section>
 
   <!-- Footer -->
-  <footer class="bg-black text-white text-center text-sm py-4">
+  <footer class="bg-black text-white text-center text-sm py-4" style="margin-top: auto;">
     © 2025 Obel AI & Quality Consultants
   </footer>
 

--- a/data.html
+++ b/data.html
@@ -19,6 +19,10 @@
       font-weight: 400;
       font-size: 16px;
       line-height: 1.5;
+      margin: 0;
+      display: flex;
+      min-height: 100vh;
+      flex-direction: column;
     }
     :root {
       --primary: #1B1F3B;
@@ -184,7 +188,7 @@
   </section>
 
   <!-- Footer -->
-  <footer class="bg-black text-white text-center text-sm py-4">
+  <footer class="bg-black text-white text-center text-sm py-4" style="margin-top: auto;">
     © 2025 Obel AI & Quality Consultants
   </footer>
 


### PR DESCRIPTION
## Summary
- remove body margin and use flex layout so pages fill the screen
- allow footer to stick to the bottom on `data.html` and `chatbot.html`

## Testing
- `apt-get update`
- `apt-get install -y w3m`
- `w3m -dump data.html | head -n 30`


------
https://chatgpt.com/codex/tasks/task_e_6856f8ce5db0832fac4fd584d1159e1f