### PR TITLE
Fix footer gap by growing feature sections

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -161,7 +161,7 @@
   </section>
 
   <!-- Features Grid with background image -->
-  <section class="relative bg-cover bg-center pb-20" style="background-image: url('assets/images/melina-kiefer-0AfMtHcK-YQ-unsplash.jpg');">
+  <section class="relative bg-cover bg-center pb-20 flex-grow" style="background-image: url('assets/images/melina-kiefer-0AfMtHcK-YQ-unsplash.jpg');">
     <div class="absolute inset-0 bg-[color:var(--overlay)]"></div>
     <div class="relative max-w-6xl mx-auto px-4 py-12">
       <div class="grid md:grid-cols-3 gap-6">

--- a/data.html
+++ b/data.html
@@ -168,7 +168,7 @@
   </section>
 
   <!-- Features Grid with background image -->
-  <section class="relative bg-cover bg-center px-4 py-12 pb-20"
+  <section class="relative bg-cover bg-center px-4 py-12 pb-20 flex-grow"
            style="background-image: url('assets/images/chris-wu-xyCpmrP_0Qo-unsplash.jpg');">
     <div class="absolute inset-0 bg-[color:var(--overlay)]"></div>
     <div class="relative max-w-6xl mx-auto grid md:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- stretch the feature image sections on `data.html` and `chatbot.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856fa391798832fa4661b61f9a67d34