### PR TITLE
Lighten navigation hover color

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,14 +46,14 @@
       transition: width 0.3s ease, left 0.3s ease;
     }
     .nav-link:hover {
-      color: var(--primary);
+      color: #323a6b;
     }
     .nav-link:hover::after {
       left: 0;
       width: 100%;
     }
     .nav-link.active {
-      color: var(--primary);
+      color: #323a6b;
     }
     .nav-link.active::after {
       left: 0;

--- a/chatbot.html
+++ b/chatbot.html
@@ -102,7 +102,7 @@
     }
     .nav-link:hover,
     .nav-link:focus {
-      color: var(--primary);
+      color: #323a6b;
     }
     .nav-link:hover::after,
     .nav-link:focus::after {

--- a/contact.html
+++ b/contact.html
@@ -45,7 +45,7 @@
       transition: width 0.3s ease, left 0.3s ease;
     }
     .nav-link:hover, .nav-link.active {
-      color: var(--primary);
+      color: #323a6b;
     }
     .nav-link:hover::after,
     .nav-link.active::after {

--- a/data.html
+++ b/data.html
@@ -109,7 +109,7 @@
       transition: width 0.3s ease, left 0.3s ease;
     }
     .nav-link:hover {
-      color: var(--primary);
+      color: #323a6b;
     }
     .nav-link:hover::after {
       left: 0;

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
       background-color: var(--primary);
       transition: width 0.3s ease, left 0.3s ease;
     }
-    .nav-link:hover { color: var(--primary); }
+    .nav-link:hover { color: #323a6b; }
     .nav-link:hover::after { left: 0; width: 100%; }
 
     /* Hero typography adjustments */

--- a/services.html
+++ b/services.html
@@ -92,7 +92,7 @@
     }
     .nav-link:hover,
     .nav-link:focus {
-      color: var(--primary);
+      color: #323a6b;
     }
     .nav-link:hover::after,
     .nav-link:focus::after {


### PR DESCRIPTION
## Summary
- adjust menu hover color to lighter shade across pages

## Testing
- `tidy -q -e index.html`
- `for f in about.html chatbot.html contact.html data.html services.html; do tidy -q -e "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6866798522d0832f82b59a70170af778